### PR TITLE
Adding safe event listeners, [Event] metadata autowiring, and a basic phase validation implementation.

### DIFF
--- a/src/utils/error/getStackTrace.as
+++ b/src/utils/error/getStackTrace.as
@@ -7,15 +7,6 @@ package utils.error
 	 */
 	public function getStackTrace():String
 	{
-		try
-		{
-			throw new Error();
-		}
-		catch (err:Error)
-		{
-			return err.getStackTrace();
-		}
-		// It's impossible to reach this
-		return null;
+		return new Error().getStackTrace();
 	}
 }

--- a/src/utils/event/addTargetEventListener.as
+++ b/src/utils/event/addTargetEventListener.as
@@ -1,12 +1,16 @@
 package utils.event
 {
-	import flash.display.DisplayObject;
+	import flash.events.IEventDispatcher;
 
-	public function addTargetEventListener(_target:DisplayObject, _type:String, _listener:Function, _useCapture:Boolean = false, _priority:int = 0, _useWeakReference:Boolean = true):void
+	public function addTargetEventListener(target:IEventDispatcher, 
+										   type:String, 
+										   listener:Function, 
+										   useWeakReference:Boolean = true, 
+										   useCapture:Boolean = false, 
+										   priority:int = 0):void
 	{
-		if (_target != null)
-		{
-			_target.addEventListener(_type, _listener, _useCapture, _priority, _useWeakReference);
-		}
+		if(!target) return;
+		
+		target.addEventListener(type, listener, useCapture, priority, useWeakReference);
 	}
 }

--- a/src/utils/event/getSafeEventHandler.as
+++ b/src/utils/event/getSafeEventHandler.as
@@ -1,0 +1,13 @@
+package utils.event
+{
+	import flash.events.Event;
+
+	public function getSafeEventHandler(func:Function):Function
+	{
+		safeEventHandlers[func] ||= function(event:Event):void {
+			func.length ? func(event) : func();
+		}
+		
+		return safeEventHandlers[func];
+	}
+}

--- a/src/utils/event/removeTargetEventListener.as
+++ b/src/utils/event/removeTargetEventListener.as
@@ -1,12 +1,15 @@
 package utils.event
 {
 	import flash.display.DisplayObject;
+	import flash.events.IEventDispatcher;
 
-	public function removeTargetEventListener(_target:DisplayObject, _type:String, _listener:Function, _useCapture:Boolean = false):void
+	public function removeTargetEventListener(target:IEventDispatcher, 
+											  type:String, 
+											  listener:Function, 
+											  useCapture:Boolean = false):void
 	{
-		if (_target != null)
-		{
-			_target.removeEventListener(_type, _listener, _useCapture);
-		}
+		if(!target) return;
+		
+		target.removeEventListener(type, listener, useCapture);
 	}
 }

--- a/src/utils/event/safeEventHandlers.as
+++ b/src/utils/event/safeEventHandlers.as
@@ -1,0 +1,5 @@
+package utils.event
+{
+	import flash.utils.Dictionary;
+	internal const safeEventHandlers:Dictionary = new Dictionary(false);
+}

--- a/src/utils/event/trashSafeEventHandler.as
+++ b/src/utils/event/trashSafeEventHandler.as
@@ -1,0 +1,12 @@
+package utils.event
+{
+	public function trashSafeEventHandler(func:Function):Function
+	{
+		if(!(func in safeEventHandlers))
+			return null;
+		
+		const handler:Function = safeEventHandlers[func];
+		delete safeEventHandlers[func];
+		return handler;
+	}
+}

--- a/src/utils/metadata/unwireEvents.as
+++ b/src/utils/metadata/unwireEvents.as
@@ -12,19 +12,20 @@ package utils.metadata
 	{
 		var methods:XMLList = describeMethods(target, 'Event');
 		var type:String;
-		var func:Function;
+		var func:*;
 		var dict:Dictionary = new Dictionary(false);
 		
 		for each(var m:XML in methods)
 		{
-			type = m.arg.@value.toString();
-			dict[func = target[m.name()]] = true;
-			removeTargetEventListener(target, type, getSafeEventHandler(func));
+			for each(var meta:XML in m.metadata.(@name=="Event"))
+			{
+				type = meta.arg.@value.toString();
+				dict[func = target[m.name()]] = true;
+				removeTargetEventListener(target, type, getSafeEventHandler(func));
+			}
 		}
 		
-		for(var myFunc:* in dict)
-			trashSafeEventHandler(myFunc);
-		
-		dict = null;
+		for(func in dict)
+			trashSafeEventHandler(func);
 	}
 }

--- a/src/utils/metadata/unwireEvents.as
+++ b/src/utils/metadata/unwireEvents.as
@@ -1,0 +1,30 @@
+package utils.metadata
+{
+	import flash.events.IEventDispatcher;
+	import flash.utils.Dictionary;
+	
+	import utils.event.getSafeEventHandler;
+	import utils.event.removeTargetEventListener;
+	import utils.event.trashSafeEventHandler;
+	import utils.type.describeMethods;
+
+	public function unwireEvents(target:IEventDispatcher):void
+	{
+		var methods:XMLList = describeMethods(target, 'Event');
+		var type:String;
+		var func:Function;
+		var dict:Dictionary = new Dictionary(false);
+		
+		for each(var m:XML in methods)
+		{
+			type = m.arg.@value.toString();
+			dict[func = target[m.name()]] = true;
+			removeTargetEventListener(target, type, getSafeEventHandler(func));
+		}
+		
+		for(var myFunc:* in dict)
+			trashSafeEventHandler(myFunc);
+		
+		dict = null;
+	}
+}

--- a/src/utils/metadata/wireEvents.as
+++ b/src/utils/metadata/wireEvents.as
@@ -12,8 +12,11 @@ package utils.metadata
 		var type:String;
 		for each(var m:XML in methods)
 		{
-			type = m.arg.@value.toString();
-			addTargetEventListener(target, type, getSafeEventHandler(target[m.name()]), false);
+			for each(var meta:XML in m.metadata.(@name=="Event"))
+			{
+				type = meta.arg.@value.toString();
+				addTargetEventListener(target, type, getSafeEventHandler(target[m.@name]), false);
+			}
 		}
 	}
 }

--- a/src/utils/metadata/wireEvents.as
+++ b/src/utils/metadata/wireEvents.as
@@ -1,0 +1,19 @@
+package utils.metadata
+{
+	import flash.events.IEventDispatcher;
+	
+	import utils.event.addTargetEventListener;
+	import utils.event.getSafeEventHandler;
+	import utils.type.describeMethods;
+
+	public function wireEvents(target:IEventDispatcher):void
+	{
+		var methods:XMLList = describeMethods(target, 'Event');
+		var type:String;
+		for each(var m:XML in methods)
+		{
+			type = m.arg.@value.toString();
+			addTargetEventListener(target, type, getSafeEventHandler(target[m.name()]), false);
+		}
+	}
+}

--- a/src/utils/syncro/Phase.as
+++ b/src/utils/syncro/Phase.as
@@ -1,5 +1,8 @@
 package utils.syncro
 {
+	import flash.events.Event;
+	import flash.events.IEventDispatcher;
+
 	internal dynamic class Phase extends Array
 	{
 		public function Phase(name:String, priority:int, ascending:Boolean)
@@ -31,7 +34,13 @@ package utils.syncro
 				reverse();
 			
 			var obj:Object;
+			
+			// Protective clone so items added during 
+			// validation don't cause an infinite loop.
 			var protect:Array = concat();
+			
+			// Clear the list so items can be added during validation. 
+			length = 0;
 			var n:int = protect.length;
 			
 			while(--n >= 0)
@@ -40,6 +49,8 @@ package utils.syncro
 				
 				if(name in obj)
 					obj[name]();
+				else if(obj is IEventDispatcher)
+					IEventDispatcher(obj).dispatchEvent(new Event(name));
 			}
 		}
 	}

--- a/src/utils/syncro/Phase.as
+++ b/src/utils/syncro/Phase.as
@@ -1,0 +1,46 @@
+package utils.syncro
+{
+	internal dynamic class Phase extends Array
+	{
+		public function Phase(name:String, priority:int, ascending:Boolean)
+		{
+			_name = name;
+			_priority = priority;
+			_ascending = ascending;
+			
+			super();
+		}
+		
+		private var _ascending:Boolean = true;
+		
+		private var _name:String = '';
+		public function get name():String
+		{
+			return _name;
+		}
+		
+		private var _priority:int = 0;
+		public function get priority():int
+		{
+			return _priority;
+		}
+		
+		public function render():void
+		{
+			if(_ascending)
+				reverse();
+			
+			var obj:Object;
+			var protect:Array = concat();
+			var n:int = protect.length;
+			
+			while(--n >= 0)
+			{
+				obj = protect.pop();
+				
+				if(name in obj)
+					obj[name]();
+			}
+		}
+	}
+}

--- a/src/utils/syncro/addphase.as
+++ b/src/utils/syncro/addphase.as
@@ -1,0 +1,11 @@
+package utils.syncro
+{
+	public function addphase(name:String, priority:int = 0, ascending:Boolean = true):void
+	{
+		if(name in syncro.names)
+			return;
+		
+		var phase:Phase = syncro.names[name] = new Phase(name, priority, ascending);
+		syncro.phases.push(phase);
+	}
+}

--- a/src/utils/syncro/invalidate.as
+++ b/src/utils/syncro/invalidate.as
@@ -1,0 +1,25 @@
+package utils.syncro
+{
+	import utils.display.wait;
+
+	public function invalidate(target:Object, depth:int, name:String):void
+	{
+		if(!(name in syncro.names))
+			return;
+		
+		var phase:Array = syncro.phases.filter(function(e:Phase, ...args):Boolean{
+			return e.name == name;
+		})[0];
+		
+		if(!phase || phase.indexOf(target) != -1)
+			return;
+		
+		phase.splice(depth, 0, target);
+		
+		if(syncro.invalidated)
+			return;
+		
+		syncro.invalidated = true;
+		wait(1, render);
+	}
+}

--- a/src/utils/syncro/render.as
+++ b/src/utils/syncro/render.as
@@ -1,0 +1,14 @@
+package utils.syncro
+{
+	public function render():void
+	{
+		var p:Array = syncro.phases;
+		p.sortOn('priority');
+		
+		//Set this before validating.
+		syncro.invalidated = false;
+		
+		for(var i:int = 0, n:int = p.length; i < n; i += 1)
+			Phase(p[i]).render();
+	}
+}

--- a/src/utils/syncro/syncro.as
+++ b/src/utils/syncro/syncro.as
@@ -1,0 +1,9 @@
+package utils.syncro
+{
+	internal class syncro
+	{
+		internal static var invalidated:Boolean = false;
+		internal static const phases:Array = [];
+		internal static const names:Array = [];
+	}
+}


### PR DESCRIPTION
Points of interest/conflict (maybe):
1. changed addListenerToTarget() method signature, promoting the useWeakListener argument above others. Some people may have strong feelings or existing code which could hinder the acceptance of this change, but the discussion is started.
2. safe listeners:
   - function wrappers to allow the real callback to optionally implement the event argument. 
   - generated function kept in a global dictionary, keyed off the function they wrap.
   - when the callback is invoked, no reflection type checking is done on the wrapped Function's argument, only a lookup on the Function.length property.
   - can introduce major memory leaks if not used carefully/correctly (this is due to Dictionary's lack of ability to use Functions as weakly referenced keys).
3. event auto-wiring simply adds the event listener on the target object. I didn't bother to implement targeting or routing from other objects, though you're free to if you wanna.
4. there's no way to remove phases after you've declared them. is this a feature you need? also, phases are based on the existing wait() function, may want to change this in the future to work with Event.RENDER also.
